### PR TITLE
Update README: Limit app to test and development

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ gem 'stylecheck', github: 'vfonic/stylecheck', require: false
 Add this line to your `Rakefile`:
 
 ```ruby
-require 'stylecheck/rake_tasks'
+require 'stylecheck/rake_tasks' unless Rails.env.production?
 ```
 
 ## Tasks


### PR DESCRIPTION
Update README to guid users to limit stylechek tasks to test and development environment. This is needed to avoid Heroku build error:
[Rails Application deploys now fail to build when Rake tasks cannot be detected](https://devcenter.heroku.com/changelog-items/841)